### PR TITLE
feat(ParserInfo): extended type to provider & language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ function translate(dockerComposeContent: string, targetPlatform: string, templat
   try {
     const dockerCompose = YAML.parse(dockerComposeContent) as any;
 
-    const parser = parsers.find(parser => parser.getInfo().abbreviation.toLowerCase() === targetPlatform.toLowerCase());
+    const parser = parsers.find(parser => parser.getInfo().languageAbbreviation.toLowerCase() === targetPlatform.toLowerCase());
     if (!parser) {
-      throw new Error(`Unsupported target platform: ${targetPlatform}`);
+      throw new Error(`Unsupported target language: ${targetPlatform}`);
     }
 
     const translatedConfig = parser.parse(dockerCompose, templateFormat);
@@ -29,9 +29,9 @@ function translate(dockerComposeContent: string, targetPlatform: string, templat
 }
 
 function getParserInfo(targetPlatform: string): ParserInfo {
-  const parser = parsers.find(parser => parser.getInfo().abbreviation.toLowerCase() === targetPlatform.toLowerCase());
+  const parser = parsers.find(parser => parser.getInfo().languageAbbreviation.toLowerCase() === targetPlatform.toLowerCase());
   if (!parser) {
-    throw new Error(`Unsupported target platform: ${targetPlatform}`);
+    throw new Error(`Unsupported target language: ${targetPlatform}`);
   }
   return parser.getInfo();
 }

--- a/src/parsers/aws-cloudformation.ts
+++ b/src/parsers/aws-cloudformation.ts
@@ -191,10 +191,12 @@ class CloudFormationParser extends BaseParser {
 
   getInfo(): ParserInfo {
     return {
-      website: 'https://aws.amazon.com/cloudformation/',
-      officialDocs: 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html',
-      abbreviation: 'CFN',
-      name: 'AWS CloudFormation',
+      providerWebsite: 'https://aws.amazon.com/cloudformation/',
+      providerName: 'Amazon Web Services',
+      provieerNameAbbreviation: 'AWS',      
+      languageOfficialDocs: 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html',
+      languageAbbreviation: 'CFN',
+      languageName: 'AWS CloudFormation',
       defaultParserConfig: defaultParserConfig
     };
   }

--- a/src/parsers/base-parser.ts
+++ b/src/parsers/base-parser.ts
@@ -1,10 +1,12 @@
 import * as YAML from 'yaml';
 
 export type ParserInfo = {
-  website: string;
-  officialDocs: string;
-  abbreviation: string;
-  name: string;
+  providerWebsite: string;
+  providerName: string;
+  provieerNameAbbreviation: string;
+  languageOfficialDocs: string;
+  languageAbbreviation: string;
+  languageName: string;
   defaultParserConfig: DefaultParserConfig
 };
 

--- a/src/parsers/render.ts
+++ b/src/parsers/render.ts
@@ -64,10 +64,12 @@ class RenderParser extends BaseParser {
 
   getInfo(): ParserInfo {
     return {
-      website: 'https://render.com/docs',
-      officialDocs: 'https://docs.render.com/infrastructure-as-code',
-      abbreviation: 'RND',
-      name: 'Render',
+      providerWebsite: 'https://render.com/docs',
+      providerName: 'Render',
+      provieerNameAbbreviation: 'RND',
+      languageOfficialDocs: 'https://docs.render.com/infrastructure-as-code',
+      languageAbbreviation: 'RND',
+      languageName: 'Render Blue Print',
       defaultParserConfig: defaultParserConfig
     };
   }


### PR DESCRIPTION
## Description

[feat(ParserInfo): extended type to provider & language](https://github.com/deploymy/docker-to-iac/commit/5cc13952bce02b321b24149a74c42d307aa01af9)

Changed Type of ParserInfo to be able to list between IaC languages and Cloud Providers.

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Minor changes in old functionality

## Checklist

- [ ] My changes are well-tested and commented
- [ ] I reviewed my changes
- [ ] My changes generate no new warnings